### PR TITLE
feat: mask env var values in logs

### DIFF
--- a/clinical-mdr-api/common/tests/unit/test_utils.py
+++ b/clinical-mdr-api/common/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 
 from common import exceptions
@@ -51,13 +52,26 @@ def test_validate_page_number_and_page_size_negative(page_number, page_size):
     )
 
 
-def test_load_env():
-    env_var1 = load_env("VAR1", "value1")
-    assert env_var1 == "value1"
+def test_load_env(monkeypatch, caplog):
+    monkeypatch.setenv("VAR1", "secret")
+    with caplog.at_level(logging.INFO):
+        env_var = load_env("VAR1", "value1")
+    assert env_var == "secret"
+    assert "VAR1" in caplog.text
+    assert "secret" not in caplog.text
 
-    env_var1 = load_env("VAR1", "")
-    assert env_var1 == ""
+    caplog.clear()
+    monkeypatch.delenv("VAR1", raising=False)
+    with caplog.at_level(logging.WARNING):
+        env_var = load_env("VAR1", "value1")
+    assert env_var == "value1"
+    assert "VAR1" in caplog.text
+    assert "value1" not in caplog.text
 
-    with pytest.raises(EnvironmentError) as exc_info:
-        load_env("VAR1")
+    caplog.clear()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(EnvironmentError) as exc_info:
+            load_env("VAR1")
     assert str(exc_info.value) == "Failed because VAR1 is not set."
+    assert "VAR1" in caplog.text
+    assert "secret" not in caplog.text

--- a/clinical-mdr-api/common/utils.py
+++ b/clinical-mdr-api/common/utils.py
@@ -348,13 +348,13 @@ def validate_max_skip_clause(page_number: int, page_size: int) -> None:
 
 def load_env(key: str, default: str | None = None):
     value = os.environ.get(key)
-    log.info("ENV variable fetched: %s=%s", key, value)
-    if value is None and default is None:
+    if value is not None:
+        log.info("ENV variable fetched: %s", key)
+        return value
+    if default is None:
         log.error("%s is not set and no default was provided", key)
         raise EnvironmentError(f"Failed because {key} is not set.")
-    if value is not None:
-        return value
-    log.warning("%s is not set, using default value: %s", key, default)
+    log.warning("%s is not set, using default value", key)
     return default
 
 


### PR DESCRIPTION
## Summary
- avoid logging raw env var values in load_env
- cover load_env logging to ensure secrets are masked

## Testing
- `NEO4J_DSN=bolt://localhost:7687 pytest clinical-mdr-api/common/tests/unit/test_utils.py::test_load_env -q`


------
https://chatgpt.com/codex/tasks/task_e_689b65d262b8832c87ca145a91dc4e7c