### PR TITLE
Guard escapeHTML against non-string inputs

### DIFF
--- a/studybuilder/src/utils/sanitize.js
+++ b/studybuilder/src/utils/sanitize.js
@@ -5,7 +5,8 @@ export function sanitizeHTML(dirtyHTML) {
 }
 
 export function escapeHTML(htmlText) {
-  return htmlText
+  const safe = typeof htmlText === 'string' ? htmlText : ''
+  return safe
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/studybuilder/tests/unit/sanitize.spec.js
+++ b/studybuilder/tests/unit/sanitize.spec.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+import { escapeHTML } from '@/utils/sanitize'
+
+describe('escapeHTML', () => {
+  it('does not throw for null input', () => {
+    expect(() => escapeHTML(null)).not.toThrow()
+  })
+
+  it('does not throw for undefined input', () => {
+    expect(() => escapeHTML(undefined)).not.toThrow()
+  })
+
+  it('does not throw for numeric input', () => {
+    expect(() => escapeHTML(42)).not.toThrow()
+  })
+})
+


### PR DESCRIPTION
## Summary
- make `escapeHTML` resilient to non-string input by coercing invalid values
- cover `escapeHTML` with unit tests for null, undefined, and numeric inputs

## Testing
- `npx eslint src/utils/sanitize.js tests/unit/sanitize.spec.js`
- `npx --yes jest@29 tests/unit/sanitize.spec.js --config=jest.config.js` *(fails: Preset @vue/cli-plugin-unit-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b65f893c0832cb0c640fe80a70696