### PR TITLE
Enforce study UID in disease milestone endpoints

### DIFF
--- a/clinical-mdr-api/clinical_mdr_api/routers/studies/study_disease_milestones.py
+++ b/clinical-mdr-api/clinical_mdr_api/routers/studies/study_disease_milestones.py
@@ -154,7 +154,7 @@ def get_distinct_values_for_header(
     field_name: Annotated[
         str, Query(description=_generic_descriptions.HEADER_FIELD_NAME)
     ],
-    study_uid: Annotated[str, studyUID],  # TODO: Use this argument!
+    study_uid: Annotated[str, studyUID],
     study_value_version: Annotated[
         str | None, _generic_descriptions.STUDY_VALUE_VERSION_QUERY
     ] = None,
@@ -177,11 +177,13 @@ def get_distinct_values_for_header(
 ) -> list[Any]:
     service = StudyDiseaseMilestoneService()
     return service.get_distinct_values_for_header(
+        study_uid=study_uid,
         field_name=field_name,
         search_string=search_string,
         filter_by=filters,
         filter_operator=FilterOperator.from_str(operator),
         page_size=page_size,
+        study_value_version=study_value_version,
     )
 
 
@@ -261,7 +263,9 @@ def get_study_disease_milestone(
     ],
 ) -> study_disease_milestone.StudyDiseaseMilestone:
     service = StudyDiseaseMilestoneService()
-    return service.find_by_uid(study_disease_milestone_uid)
+    return service.find_by_uid(
+        study_uid=study_uid, uid=study_disease_milestone_uid
+    )
 
 
 @router.get(
@@ -383,14 +387,16 @@ Possible errors:
 @decorators.validate_if_study_is_not_locked("study_uid")
 # pylint: disable=unused-argument
 def delete_study_disease_milestone(
-    study_uid: Annotated[str, studyUID],  # TODO: Use this argument!
+    study_uid: Annotated[str, studyUID],
     study_disease_milestone_uid: Annotated[
         str, study_disease_milestone_uid_description
     ],
 ):
     service = StudyDiseaseMilestoneService()
-
-    service.delete(study_disease_milestone_uid=study_disease_milestone_uid)
+    service.delete(
+        study_uid=study_uid,
+        study_disease_milestone_uid=study_disease_milestone_uid,
+    )
 
 
 @router.patch(
@@ -436,7 +442,7 @@ Possible errors:
 @decorators.validate_if_study_is_not_locked("study_uid")
 # pylint: disable=unused-argument
 def patch_reorder(
-    study_uid: Annotated[str, studyUID],  # TODO: Use this argument!
+    study_uid: Annotated[str, studyUID],
     study_disease_milestone_uid: Annotated[
         str, study_disease_milestone_uid_description
     ],
@@ -447,6 +453,7 @@ def patch_reorder(
 ) -> study_disease_milestone.StudyDiseaseMilestone:
     service = StudyDiseaseMilestoneService()
     return service.reorder(
+        study_uid=study_uid,
         study_disease_milestone_uid=study_disease_milestone_uid,
         new_order=new_order_input.new_order,
     )
@@ -497,6 +504,7 @@ def patch_update_disease_milestone(
 ) -> study_disease_milestone.StudyDiseaseMilestone:
     service = StudyDiseaseMilestoneService()
     return service.edit(
+        study_uid=study_uid,
         study_disease_milestone_uid=study_disease_milestone_uid,
         study_disease_milestone_input=selection,
     )

--- a/clinical-mdr-api/clinical_mdr_api/tests/integration/api/study_selections/test_study_disease_milestone.py
+++ b/clinical-mdr-api/clinical_mdr_api/tests/integration/api/study_selections/test_study_disease_milestone.py
@@ -204,3 +204,37 @@ def test_get_disease_milestones_csv_xml_excel(api_client, export_format):
     if export_format == "text/csv":
         assert "study_version" in str(exported_data.read())
         assert "LATEST" in str(exported_data.read())
+
+
+def test_study_uid_scope_enforced(api_client):
+    other_study = TestUtils.create_study()
+    TestUtils.set_study_standard_version(study_uid=other_study.uid)
+
+    response = api_client.get(
+        f"/studies/{other_study.uid}/study-disease-milestones/{disease_milestone_uid}"
+    )
+    assert_response_status_code(response, 404)
+
+    response = api_client.delete(
+        f"/studies/{other_study.uid}/study-disease-milestones/{disease_milestone_uid}"
+    )
+    assert_response_status_code(response, 404)
+
+    response = api_client.patch(
+        f"/studies/{other_study.uid}/study-disease-milestones/{disease_milestone_uid}/order",
+        json={"new_order": 1},
+    )
+    assert_response_status_code(response, 404)
+
+    response = api_client.patch(
+        f"/studies/{other_study.uid}/study-disease-milestones/{disease_milestone_uid}",
+        json={"repetition_indicator": False},
+    )
+    assert_response_status_code(response, 404)
+
+    response = api_client.get(
+        f"/studies/{other_study.uid}/study-disease-milestones/headers",
+        params={"field_name": "disease_milestone_type"},
+    )
+    assert_response_status_code(response, 200)
+    assert response.json() == []

--- a/clinical-mdr-api/clinical_mdr_api/tests/integration/services/test_study_disease_milestone.py
+++ b/clinical-mdr-api/clinical_mdr_api/tests/integration/services/test_study_disease_milestone.py
@@ -85,35 +85,35 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
             disease_milestone_type="Disease_Milestone_Type_0003"
         )
 
-        dm1 = disease_milestone_service.find_by_uid(dm1.uid)
-        dm2 = disease_milestone_service.find_by_uid(dm2.uid)
-        dm3 = disease_milestone_service.find_by_uid(dm3.uid)
+        dm1 = disease_milestone_service.find_by_uid(self.study.uid, dm1.uid)
+        dm2 = disease_milestone_service.find_by_uid(self.study.uid, dm2.uid)
+        dm3 = disease_milestone_service.find_by_uid(self.study.uid, dm3.uid)
 
         self.assertEqual(dm1.order, 1)
         self.assertEqual(dm2.order, 2)
         self.assertEqual(dm3.order, 3)
 
         with self.assertRaises(exceptions.BusinessLogicException):
-            disease_milestone_service.reorder(dm3.uid, 0)
+            disease_milestone_service.reorder(self.study.uid, dm3.uid, 0)
 
         with self.assertRaises(exceptions.BusinessLogicException):
-            disease_milestone_service.reorder(dm3.uid, 4)
+            disease_milestone_service.reorder(self.study.uid, dm3.uid, 4)
 
-        disease_milestone_service.reorder(dm3.uid, 1)
+        disease_milestone_service.reorder(self.study.uid, dm3.uid, 1)
 
-        dm_after1 = disease_milestone_service.find_by_uid(dm1.uid)
-        dm_after2 = disease_milestone_service.find_by_uid(dm2.uid)
-        dm_after3 = disease_milestone_service.find_by_uid(dm3.uid)
+        dm_after1 = disease_milestone_service.find_by_uid(self.study.uid, dm1.uid)
+        dm_after2 = disease_milestone_service.find_by_uid(self.study.uid, dm2.uid)
+        dm_after3 = disease_milestone_service.find_by_uid(self.study.uid, dm3.uid)
 
         self.assertEqual(dm_after1.order, 2)
         self.assertEqual(dm_after2.order, 3)
         self.assertEqual(dm_after3.order, 1)
 
-        disease_milestone_service.reorder(dm1.uid, 3)
+        disease_milestone_service.reorder(self.study.uid, dm1.uid, 3)
 
-        dm_after1 = disease_milestone_service.find_by_uid(dm1.uid)
-        dm_after2 = disease_milestone_service.find_by_uid(dm2.uid)
-        dm_after3 = disease_milestone_service.find_by_uid(dm3.uid)
+        dm_after1 = disease_milestone_service.find_by_uid(self.study.uid, dm1.uid)
+        dm_after2 = disease_milestone_service.find_by_uid(self.study.uid, dm2.uid)
+        dm_after3 = disease_milestone_service.find_by_uid(self.study.uid, dm3.uid)
 
         self.assertEqual(dm_after1.order, 3)
         self.assertEqual(dm_after2.order, 2)
@@ -125,17 +125,26 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
         disease_milestone_subtype_3 = create_study_disease_milestone(
             disease_milestone_type="Disease_Milestone_Type_0005"
         )
-        dm4 = disease_milestone_service.find_by_uid(disease_milestone_subtype_2.uid)
+        dm4 = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone_subtype_2.uid
+        )
         self.assertEqual(dm4.order, 4)
-        dm5 = disease_milestone_service.find_by_uid(disease_milestone_subtype_3.uid)
+        dm5 = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone_subtype_3.uid
+        )
         self.assertEqual(dm5.order, 5)
-        disease_milestone_service.reorder(dm5.uid, 4)
-        dm4 = disease_milestone_service.find_by_uid(disease_milestone_subtype_2.uid)
+        disease_milestone_service.reorder(self.study.uid, dm5.uid, 4)
+        dm4 = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone_subtype_2.uid
+        )
         self.assertEqual(dm4.order, 5)
-        dm5 = disease_milestone_service.find_by_uid(disease_milestone_subtype_3.uid)
+        dm5 = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone_subtype_3.uid
+        )
         self.assertEqual(dm5.order, 4)
 
         header = disease_milestone_service.get_distinct_values_for_header(
+            study_uid=self.study.uid,
             field_name="disease_milestone_type",
             search_string="",
             filter_by="",
@@ -187,7 +196,9 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
 
         disease_milestone_service = StudyDiseaseMilestoneService()
 
-        disease_milestone = disease_milestone_service.find_by_uid(disease_milestone.uid)
+        disease_milestone = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone.uid
+        )
         disease_milestone_type = "Disease_Milestone_Type_0003"
         repetition_indicator = False
         edit_input = StudyDiseaseMilestoneEditInput(
@@ -200,11 +211,12 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
         TestUtils.create_study_fields_configuration()
         TestUtils.lock_and_unlock_study(study_uid="study_root")
         edited_disease_milestone = disease_milestone_service.edit(
+            study_uid=self.study.uid,
             study_disease_milestone_uid=disease_milestone.uid,
             study_disease_milestone_input=edit_input,
         )
         edited_disease_milestone = disease_milestone_service.find_by_uid(
-            edited_disease_milestone.uid
+            self.study.uid, edited_disease_milestone.uid
         )
         self.assertEqual(
             edited_disease_milestone.disease_milestone_type,
@@ -221,7 +233,9 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
             disease_milestone_type="Disease_Milestone_Type_0001"
         )
         disease_milestone_service = StudyDiseaseMilestoneService()
-        disease_milestone = disease_milestone_service.find_by_uid(disease_milestone.uid)
+        disease_milestone = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone.uid
+        )
         start_rule = "New start rule"
         end_rule = "New end rule"
         edit_input = StudyDiseaseMilestoneEditInput(
@@ -232,6 +246,7 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
             disease_milestone_type="Disease_Milestone_Type_0002",
         )
         disease_milestone_service.edit(
+            study_uid=self.study.uid,
             study_disease_milestone_uid=disease_milestone.uid,
             study_disease_milestone_input=edit_input,
         )
@@ -247,12 +262,15 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
             disease_milestone_type="Disease_Milestone_Type_0003"
         )
         disease_milestone_service = StudyDiseaseMilestoneService()
-        disease_milestone = disease_milestone_service.find_by_uid(disease_milestone.uid)
+        disease_milestone = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone.uid
+        )
         edit_input = StudyDiseaseMilestoneEditInput(
             study_uid=disease_milestone.study_uid,
             change_description="rules change",
         )
         disease_milestone_service.edit(
+            study_uid=self.study.uid,
             study_disease_milestone_uid=disease_milestone.uid,
             study_disease_milestone_input=edit_input,
         )
@@ -288,9 +306,9 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
             disease_milestone_type="Disease_Milestone_Type_0004"
         )
 
-        dm1 = disease_milestone_service.find_by_uid(disease_milestone1.uid)
-        dm2 = disease_milestone_service.find_by_uid(disease_milestone2.uid)
-        dm3 = disease_milestone_service.find_by_uid(disease_milestone3.uid)
+        dm1 = disease_milestone_service.find_by_uid(self.study.uid, disease_milestone1.uid)
+        dm2 = disease_milestone_service.find_by_uid(self.study.uid, disease_milestone2.uid)
+        dm3 = disease_milestone_service.find_by_uid(self.study.uid, disease_milestone3.uid)
 
         self.assertEqual(dm1.order, 2)
         self.assertEqual(dm2.order, 3)
@@ -300,23 +318,31 @@ class TestStudyDiseaseMilestoneManagement(unittest.TestCase):
         TestUtils.create_study_fields_configuration()
         TestUtils.lock_and_unlock_study(study_uid="study_root")
 
-        disease_milestone_service.delete(study_disease_milestone_uid=dm1.uid)
+        disease_milestone_service.delete(
+            study_uid=self.study.uid, study_disease_milestone_uid=dm1.uid
+        )
 
-        dm1 = disease_milestone_service.find_by_uid(disease_milestone2.uid)
-        dm2 = disease_milestone_service.find_by_uid(disease_milestone3.uid)
+        dm1 = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone2.uid
+        )
+        dm2 = disease_milestone_service.find_by_uid(
+            self.study.uid, disease_milestone3.uid
+        )
 
         self.assertEqual(dm1.order, 2)
         self.assertEqual(dm2.order, 3)
 
-        disease_milestone_service.delete(study_disease_milestone_uid=dm1.uid)
-        dm1 = disease_milestone_service.find_by_uid(dm2.uid)
+        disease_milestone_service.delete(
+            study_uid=self.study.uid, study_disease_milestone_uid=dm1.uid
+        )
+        dm1 = disease_milestone_service.find_by_uid(self.study.uid, dm2.uid)
         self.assertEqual(dm1.order, 2)
 
         disease_milestone_recreate = create_study_disease_milestone(
             disease_milestone_type="Disease_Milestone_Type_0002"
         )
         dm_recreate = disease_milestone_service.find_by_uid(
-            disease_milestone_recreate.uid
+            self.study.uid, disease_milestone_recreate.uid
         )
         self.assertEqual(dm_recreate.order, 3)
 


### PR DESCRIPTION
## Summary
- enforce study scoping across disease milestone endpoints and services
- ensure repository queries and header lookups filter by study UID
- add regression test rejecting cross-study disease milestone access

## Testing
- `NEO4J_DSN=bolt://localhost:7687 pytest clinical_mdr_api/tests/integration/api/study_selections/test_study_disease_milestone.py` *(fails: TypeError: Too few arguments for typing.Generator)*
- `NEO4J_DSN=bolt://localhost:7687 pytest clinical_mdr_api/tests/integration/services/test_study_disease_milestone.py` *(fails: TypeError: Too few arguments for typing.Generator)*

------
https://chatgpt.com/codex/tasks/task_e_689b647d0af4832c8ced21bdb5eee1fa