### PR TITLE
chore: translate template sections

### DIFF
--- a/studybuilder/src/locales/de-DE.json
+++ b/studybuilder/src/locales/de-DE.json
@@ -222,8 +222,8 @@
             "context": "The Context attribute specifies the application domain in which this additional name is relevant. You could use for example 'CDASH/SDTM' with a 'Name' = 'DM:Demographics|DS:Disposition' and then the ODM-XML view will display it as an annotation for two SDTM Domain."
         },
         "GenericTemplateForm": {
-            "study_indication": "Indications, conditions, diseases or disorders in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies.",
-            "study_phase": "Study phases in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies."
+            "study_indication": "Indikationen, Zustände, Krankheiten oder Störungen, die für die Vorlage gelten. Wählen Sie NA (nicht zutreffend), wenn die Vorlage allgemein ist und sich nicht auf bestimmte Studien richtet.",
+            "study_phase": "Studienphasen, die für die Vorlage gelten. Wählen Sie NA (nicht zutreffend), wenn die Vorlage allgemein ist und sich nicht auf bestimmte Studien richtet."
         },
         "ObjectiveTemplateForm": {
             "name": "Example of objective: 'To demonstrate superiority of [CompoundDosing] [NumericValue] [Dose Unit] versus [Comparator] [NumericValue] [Dose Unit] with respect to [ActivityInstance] at [TimePoint] in patients with [DiseaseDisorder]' or 'To document the safety profile of [StudyIntervention].' Add parameters enclosed in square brackets [ and ].",
@@ -1189,22 +1189,22 @@
         "integrate_text2": "via open API"
     },
     "GenericTemplateTable": {
-        "sponsor_tab": "Parent",
-        "pre_instances_tab": "Pre-instance",
-        "user_tab": "User Defined",
-        "confirm_parameter_values_delete": "You are about to delete default parameter values",
-        "template_history_title": "History for template [{templateUid}]"
+        "sponsor_tab": "Übergeordnet",
+        "pre_instances_tab": "Vorinstanz",
+        "user_tab": "Benutzerdefiniert",
+        "confirm_parameter_values_delete": "Sie sind dabei, Standardparameterwerte zu löschen",
+        "template_history_title": "Verlauf für Vorlage [{templateUid}]"
     },
     "GenericTemplateForm": {
-        "study_indication": "Indication or disorder",
-        "study_phase": "Study phase",
-        "template_properties": "Template properties",
-        "step1_add_title": "Create template",
-        "step1_edit_title": "Edit template",
-        "step2_title": "Test template",
-        "step3_title": "Index template",
-        "step4_title": "Change description",
-        "parameter_values_title": "Edit parameter values"
+        "study_indication": "Indikation oder Störung",
+        "study_phase": "Studienphase",
+        "template_properties": "Vorlageneigenschaften",
+        "step1_add_title": "Vorlage erstellen",
+        "step1_edit_title": "Vorlage bearbeiten",
+        "step2_title": "Vorlage testen",
+        "step3_title": "Vorlage indizieren",
+        "step4_title": "Änderungsbeschreibung",
+        "parameter_values_title": "Parameterwerte bearbeiten"
     },
     "EndpointTemplatesView": {
         "title": "Endpoint Templates",
@@ -1313,38 +1313,38 @@
         "confirmatory_testing": "Related to confirmatory testing"
     },
     "PreInstanceForm": {
-        "step1_title": "Set template parameter values",
-        "step2_title": "Index template"
+        "step1_title": "Vorlagenparameterwerte festlegen",
+        "step2_title": "Vorlage indizieren"
     },
     "ObjectiveTemplatesPreInstanceForm": {
-        "add_title": "Add objective template pre-instantiation",
-        "edit_title": "Edit objective template pre-instantiation",
-        "add_success": "Objective template pre-instantiation added",
-        "update_success": "Objective template pre-instantiation updated"
+        "add_title": "Vorinstanz der Zielvorlage hinzufügen",
+        "edit_title": "Vorinstanz der Zielvorlage bearbeiten",
+        "add_success": "Vorinstanz der Zielvorlage hinzugefügt",
+        "update_success": "Vorinstanz der Zielvorlage aktualisiert"
     },
     "EndpointTemplatesPreInstanceForm": {
-        "add_title": "Add endpoint template pre-instantiation",
-        "edit_title": "Edit endpoint template pre-instantiation",
-        "add_success": "Endpoint template pre-instantiation added",
-        "update_success": "Endpoint template pre-instantiation updated"
+        "add_title": "Vorinstanz der Endpunktvorlage hinzufügen",
+        "edit_title": "Vorinstanz der Endpunktvorlage bearbeiten",
+        "add_success": "Vorinstanz der Endpunktvorlage hinzugefügt",
+        "update_success": "Vorinstanz der Endpunktvorlage aktualisiert"
     },
     "CriteriaTemplatesPreInstanceForm": {
-        "add_title": "Add criteria template pre-instantiation",
-        "edit_title": "Edit criteria template pre-instantiation",
-        "add_success": "Criteria template pre-instantiation added",
-        "update_success": "Criteria template pre-instantiation updated"
+        "add_title": "Vorinstanz der Kriterienvorlage hinzufügen",
+        "edit_title": "Vorinstanz der Kriterienvorlage bearbeiten",
+        "add_success": "Vorinstanz der Kriterienvorlage hinzugefügt",
+        "update_success": "Vorinstanz der Kriterienvorlage aktualisiert"
     },
     "ActivityTemplatesPreInstanceForm": {
-        "add_title": "Add activity template pre-instantiation",
-        "edit_title": "Edit activity template pre-instantiation",
-        "add_success": "Activity template pre-instantiation added",
-        "update_success": "Activity template pre-instantiation updated"
+        "add_title": "Vorinstanz der Aktivitätsvorlage hinzufügen",
+        "edit_title": "Vorinstanz der Aktivitätsvorlage bearbeiten",
+        "add_success": "Vorinstanz der Aktivitätsvorlage hinzugefügt",
+        "update_success": "Vorinstanz der Aktivitätsvorlage aktualisiert"
     },
     "FootnoteTemplatesPreInstanceForm": {
-        "add_title": "Add footnote template pre-instantiation",
-        "edit_title": "Edit footnote template pre-instantiation",
-        "add_success": "Footnote template pre-instantiation added",
-        "update_success": "Footnote template pre-instantiation updated"
+        "add_title": "Vorinstanz der Fußnotenvorlage hinzufügen",
+        "edit_title": "Vorinstanz der Fußnotenvorlage bearbeiten",
+        "add_success": "Vorinstanz der Fußnotenvorlage hinzugefügt",
+        "update_success": "Vorinstanz der Fußnotenvorlage aktualisiert"
     },
     "CtCataloguesForm": {
         "add_title": "Add a new CT Catalogue",
@@ -1745,10 +1745,10 @@
         "objective_updated": "Study objective updated"
     },
     "ParameterValueSelector": {
-        "separator": "Separator",
-        "title": "Select values",
-        "preview": "Preview with selected values",
-        "na_tooltip": "Show/hide parameter in the sentence"
+        "separator": "Trennzeichen",
+        "title": "Werte auswählen",
+        "preview": "Vorschau mit ausgewählten Werten",
+        "na_tooltip": "Parameter im Satz ein-/ausblenden"
     },
     "StudyManageView": {
         "title": "Study List"
@@ -3914,8 +3914,8 @@
         "format": "Format"
     },
     "TemplateIndexingDialog": {
-        "title": "Edit indexing properties",
-        "update_success": "Indexing properties updated"
+        "title": "Indexeigenschaften bearbeiten",
+        "update_success": "Indexeigenschaften aktualisiert"
     },
     "CrfDuplicationForm": {
         "duplicate": "Duplicate element",

--- a/studybuilder/src/locales/es-419.json
+++ b/studybuilder/src/locales/es-419.json
@@ -222,8 +222,8 @@
             "context": "El atributo de contexto especifica el dominio de la aplicación en el que este nombre adicional es relevante. "
         },
         "GenericTemplateForm": {
-            "study_indication": "Indicaciones, condiciones, enfermedades o trastornos en el alcance de la plantilla. ",
-            "study_phase": "Fases de estudio en el alcance de la plantilla. "
+            "study_indication": "Indicaciones, condiciones, enfermedades o trastornos que abarca la plantilla. Seleccione NA (no aplica) si la plantilla es genérica y no está dirigida a estudios específicos.",
+            "study_phase": "Fases del estudio que abarca la plantilla. Seleccione NA (no aplica) si la plantilla es genérica y no está dirigida a estudios específicos."
         },
         "ObjectiveTemplateForm": {
             "name": "Ejemplo de objetivo: 'Demostrar superioridad de [compuesto -doste] [numericvalue] [unidad de dosis] versus [comparador] [NumericValue] [Unidad de dosis] con respecto a [Activity Instance] en [TimePoint] en pacientes con [EnfermateSorder]' o 'Documentar el perfil de seguridad de [Studyervention]. ",
@@ -1189,20 +1189,20 @@
         "integrate_text2": "a través de API abierta"
     },
     "GenericTemplateTable": {
-        "sponsor_tab": "Padre",
-        "pre_instances_tab": "Previa",
-        "user_tab": "Usuario definido",
-        "confirm_parameter_values_delete": "Está a punto de eliminar los valores de parámetros predeterminados",
-        "template_history_title": "Historia para la plantilla [__ph_0__]"
+        "sponsor_tab": "Principal",
+        "pre_instances_tab": "Preinstancia",
+        "user_tab": "Definido por el usuario",
+        "confirm_parameter_values_delete": "Está a punto de eliminar los valores de parámetro predeterminados",
+        "template_history_title": "Historial de la plantilla [{templateUid}]"
     },
     "GenericTemplateForm": {
-        "study_indication": "Indicación o desorden",
-        "study_phase": "Fase de estudio",
-        "template_properties": "Propiedades de plantilla",
+        "study_indication": "Indicación o trastorno",
+        "study_phase": "Fase del estudio",
+        "template_properties": "Propiedades de la plantilla",
         "step1_add_title": "Crear plantilla",
-        "step1_edit_title": "Plantilla de edición",
-        "step2_title": "Plantilla de prueba",
-        "step3_title": "Plantilla de índice",
+        "step1_edit_title": "Editar plantilla",
+        "step2_title": "Probar plantilla",
+        "step3_title": "Indexar plantilla",
         "step4_title": "Descripción del cambio",
         "parameter_values_title": "Editar valores de parámetros"
     },
@@ -1313,38 +1313,38 @@
         "confirmatory_testing": "Relacionado con las pruebas confirmatorias"
     },
     "PreInstanceForm": {
-        "step1_title": "Establecer valores de parámetros de plantilla",
-        "step2_title": "Plantilla de índice"
+        "step1_title": "Definir valores de parámetros de la plantilla",
+        "step2_title": "Indexar plantilla"
     },
     "ObjectiveTemplatesPreInstanceForm": {
-        "add_title": "Agregar plantilla de objetivos preinstanciación",
-        "edit_title": "Editar plantilla de objetivos preinstanciación",
-        "add_success": "Plantilla de objetivos Precinstanciación agregada",
-        "update_success": "Plantilla de objetivos Precinstanciación actualizada"
+        "add_title": "Agregar preinstancia de plantilla de objetivo",
+        "edit_title": "Editar preinstancia de plantilla de objetivo",
+        "add_success": "Preinstancia de plantilla de objetivo agregada",
+        "update_success": "Preinstancia de plantilla de objetivo actualizada"
     },
     "EndpointTemplatesPreInstanceForm": {
-        "add_title": "Agregar plantilla de punto final preinstanciación",
-        "edit_title": "Editar plantilla de punto final preinstanciación",
-        "add_success": "Plantilla de punto final preinstanciación agregada",
-        "update_success": "Plantilla de punto final preinstanciación actualizada"
+        "add_title": "Agregar preinstancia de plantilla de criterio de valoración",
+        "edit_title": "Editar preinstancia de plantilla de criterio de valoración",
+        "add_success": "Preinstancia de plantilla de criterio de valoración agregada",
+        "update_success": "Preinstancia de plantilla de criterio de valoración actualizada"
     },
     "CriteriaTemplatesPreInstanceForm": {
-        "add_title": "Agregar plantilla de criterios preinstanciación",
-        "edit_title": "Editar plantilla de criterios preinstanciación",
-        "add_success": "Plantilla de criterios Precinstanciación agregada",
-        "update_success": "Plantilla de criterios preinstanciación actualizada"
+        "add_title": "Agregar preinstancia de plantilla de criterio",
+        "edit_title": "Editar preinstancia de plantilla de criterio",
+        "add_success": "Preinstancia de plantilla de criterio agregada",
+        "update_success": "Preinstancia de plantilla de criterio actualizada"
     },
     "ActivityTemplatesPreInstanceForm": {
-        "add_title": "Agregar plantilla de actividad preinstanciación",
-        "edit_title": "Editar plantilla de actividad preinstanciación",
-        "add_success": "Plantilla de actividad previa a la instanciación agregada",
-        "update_success": "Plantilla de actividad preinstanciación actualizada"
+        "add_title": "Agregar preinstancia de plantilla de actividad",
+        "edit_title": "Editar preinstancia de plantilla de actividad",
+        "add_success": "Preinstancia de plantilla de actividad agregada",
+        "update_success": "Preinstancia de plantilla de actividad actualizada"
     },
     "FootnoteTemplatesPreInstanceForm": {
-        "add_title": "Agregar plantilla de nota al pie Precinstanciación",
-        "edit_title": "Editar plantilla de nota al pie de la preinstanciación",
-        "add_success": "Plantilla de nota al pie preinstanciación agregada",
-        "update_success": "Plantilla de nota al pie Precinstanciación actualizada"
+        "add_title": "Agregar preinstancia de plantilla de nota al pie",
+        "edit_title": "Editar preinstancia de plantilla de nota al pie",
+        "add_success": "Preinstancia de plantilla de nota al pie agregada",
+        "update_success": "Preinstancia de plantilla de nota al pie actualizada"
     },
     "CtCataloguesForm": {
         "add_title": "Agregue un nuevo catálogo de CT",
@@ -1747,7 +1747,7 @@
     "ParameterValueSelector": {
         "separator": "Separador",
         "title": "Seleccionar valores",
-        "preview": "Vista previa con valores seleccionados",
+        "preview": "Vista previa con los valores seleccionados",
         "na_tooltip": "Mostrar/ocultar el parámetro en la oración"
     },
     "StudyManageView": {

--- a/studybuilder/src/locales/fr-FR.json
+++ b/studybuilder/src/locales/fr-FR.json
@@ -222,8 +222,8 @@
             "context": "The Context attribute specifies the application domain in which this additional name is relevant. You could use for example 'CDASH/SDTM' with a 'Name' = 'DM:Demographics|DS:Disposition' and then the ODM-XML view will display it as an annotation for two SDTM Domain."
         },
         "GenericTemplateForm": {
-            "study_indication": "Indications, conditions, diseases or disorders in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies.",
-            "study_phase": "Study phases in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies."
+            "study_indication": "Indications, affections, maladies ou troubles couverts par le modèle. Sélectionnez NA (non applicable) si le modèle est générique et ne cible pas d'études spécifiques.",
+            "study_phase": "Phases d'étude couvertes par le modèle. Sélectionnez NA (non applicable) si le modèle est générique et ne vise aucune étude spécifique."
         },
         "ObjectiveTemplateForm": {
             "name": "Example of objective: 'To demonstrate superiority of [CompoundDosing] [NumericValue] [Dose Unit] versus [Comparator] [NumericValue] [Dose Unit] with respect to [ActivityInstance] at [TimePoint] in patients with [DiseaseDisorder]' or 'To document the safety profile of [StudyIntervention].' Add parameters enclosed in square brackets [ and ].",
@@ -1190,21 +1190,21 @@
     },
     "GenericTemplateTable": {
         "sponsor_tab": "Parent",
-        "pre_instances_tab": "Pre-instance",
-        "user_tab": "User Defined",
-        "confirm_parameter_values_delete": "You are about to delete default parameter values",
-        "template_history_title": "History for template [{templateUid}]"
+        "pre_instances_tab": "Pré‑instance",
+        "user_tab": "Défini par l'utilisateur",
+        "confirm_parameter_values_delete": "Vous êtes sur le point de supprimer les valeurs de paramètre par défaut",
+        "template_history_title": "Historique du modèle [{templateUid}]"
     },
     "GenericTemplateForm": {
-        "study_indication": "Indication or disorder",
-        "study_phase": "Study phase",
-        "template_properties": "Template properties",
-        "step1_add_title": "Create template",
-        "step1_edit_title": "Edit template",
-        "step2_title": "Test template",
-        "step3_title": "Index template",
-        "step4_title": "Change description",
-        "parameter_values_title": "Edit parameter values"
+        "study_indication": "Indication ou trouble",
+        "study_phase": "Phase d'étude",
+        "template_properties": "Propriétés du modèle",
+        "step1_add_title": "Créer un modèle",
+        "step1_edit_title": "Modifier le modèle",
+        "step2_title": "Tester le modèle",
+        "step3_title": "Indexer le modèle",
+        "step4_title": "Description des changements",
+        "parameter_values_title": "Modifier les valeurs de paramètre"
     },
     "EndpointTemplatesView": {
         "title": "Endpoint Templates",
@@ -1313,38 +1313,38 @@
         "confirmatory_testing": "Related to confirmatory testing"
     },
     "PreInstanceForm": {
-        "step1_title": "Set template parameter values",
-        "step2_title": "Index template"
+        "step1_title": "Définir les valeurs de paramètre du modèle",
+        "step2_title": "Indexer le modèle"
     },
     "ObjectiveTemplatesPreInstanceForm": {
-        "add_title": "Add objective template pre-instantiation",
-        "edit_title": "Edit objective template pre-instantiation",
-        "add_success": "Objective template pre-instantiation added",
-        "update_success": "Objective template pre-instantiation updated"
+        "add_title": "Ajouter une pré‑instanciation de modèle d'objectif",
+        "edit_title": "Modifier la pré‑instanciation de modèle d'objectif",
+        "add_success": "Pré‑instanciation de modèle d'objectif ajoutée",
+        "update_success": "Pré‑instanciation de modèle d'objectif mise à jour"
     },
     "EndpointTemplatesPreInstanceForm": {
-        "add_title": "Add endpoint template pre-instantiation",
-        "edit_title": "Edit endpoint template pre-instantiation",
-        "add_success": "Endpoint template pre-instantiation added",
-        "update_success": "Endpoint template pre-instantiation updated"
+        "add_title": "Ajouter une pré‑instanciation de modèle de critère d'évaluation",
+        "edit_title": "Modifier la pré‑instanciation de modèle de critère d'évaluation",
+        "add_success": "Pré‑instanciation de modèle de critère d'évaluation ajoutée",
+        "update_success": "Pré‑instanciation de modèle de critère d'évaluation mise à jour"
     },
     "CriteriaTemplatesPreInstanceForm": {
-        "add_title": "Add criteria template pre-instantiation",
-        "edit_title": "Edit criteria template pre-instantiation",
-        "add_success": "Criteria template pre-instantiation added",
-        "update_success": "Criteria template pre-instantiation updated"
+        "add_title": "Ajouter une pré‑instanciation de modèle de critère",
+        "edit_title": "Modifier la pré‑instanciation de modèle de critère",
+        "add_success": "Pré‑instanciation de modèle de critère ajoutée",
+        "update_success": "Pré‑instanciation de modèle de critère mise à jour"
     },
     "ActivityTemplatesPreInstanceForm": {
-        "add_title": "Add activity template pre-instantiation",
-        "edit_title": "Edit activity template pre-instantiation",
-        "add_success": "Activity template pre-instantiation added",
-        "update_success": "Activity template pre-instantiation updated"
+        "add_title": "Ajouter une pré‑instanciation de modèle d'activité",
+        "edit_title": "Modifier la pré‑instanciation de modèle d'activité",
+        "add_success": "Pré‑instanciation de modèle d'activité ajoutée",
+        "update_success": "Pré‑instanciation de modèle d'activité mise à jour"
     },
     "FootnoteTemplatesPreInstanceForm": {
-        "add_title": "Add footnote template pre-instantiation",
-        "edit_title": "Edit footnote template pre-instantiation",
-        "add_success": "Footnote template pre-instantiation added",
-        "update_success": "Footnote template pre-instantiation updated"
+        "add_title": "Ajouter une pré‑instanciation de modèle de note de bas de page",
+        "edit_title": "Modifier la pré‑instanciation de modèle de note de bas de page",
+        "add_success": "Pré‑instanciation de modèle de note de bas de page ajoutée",
+        "update_success": "Pré‑instanciation de modèle de note de bas de page mise à jour"
     },
     "CtCataloguesForm": {
         "add_title": "Add a new CT Catalog",
@@ -1745,10 +1745,10 @@
         "objective_updated": "Study objective updated"
     },
     "ParameterValueSelector": {
-        "separator": "Separator",
-        "title": "Select values",
-        "preview": "Preview with selected values",
-        "na_tooltip": "Show/hide parameter in the sentence"
+        "separator": "Séparateur",
+        "title": "Sélectionner les valeurs",
+        "preview": "Aperçu avec les valeurs sélectionnées",
+        "na_tooltip": "Afficher/masquer le paramètre dans la phrase"
     },
     "StudyManageView": {
         "title": "Study List"
@@ -3914,8 +3914,8 @@
         "format": "Format"
     },
     "TemplateIndexingDialog": {
-        "title": "Edit indexing properties",
-        "update_success": "Indexing properties updated"
+        "title": "Modifier les propriétés d'indexation",
+        "update_success": "Propriétés d'indexation mises à jour"
     },
     "CrfDuplicationForm": {
         "duplicate": "Duplicate element",

--- a/studybuilder/src/locales/ko-KR.json
+++ b/studybuilder/src/locales/ko-KR.json
@@ -222,8 +222,8 @@
             "context": "The Context attribute specifies the application domain in which this additional name is relevant. You could use for example 'CDASH/SDTM' with a 'Name' = 'DM:Demographics|DS:Disposition' and then the ODM-XML view will display it as an annotation for two SDTM Domain."
         },
         "GenericTemplateForm": {
-            "study_indication": "Indications, conditions, diseases or disorders in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies.",
-            "study_phase": "Study phases in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies."
+            "study_indication": "템플릿이 적용되는 적응증, 상태, 질병 또는 장애. 템플릿이 특정 연구를 대상으로 하지 않는 일반 템플릿인 경우 NA(해당 없음)를 선택하세요.",
+            "study_phase": "템플릿이 적용되는 연구 단계. 템플릿이 특정 연구를 대상으로 하지 않는 일반 템플릿인 경우 NA(해당 없음)를 선택하세요."
         },
         "ObjectiveTemplateForm": {
             "name": "Example of objective: 'To demonstrate superiority of [CompoundDosing] [NumericValue] [Dose Unit] versus [Comparator] [NumericValue] [Dose Unit] with respect to [ActivityInstance] at [TimePoint] in patients with [DiseaseDisorder]' or 'To document the safety profile of [StudyIntervention].' Add parameters enclosed in square brackets [ and ].",
@@ -1189,22 +1189,22 @@
         "integrate_text2": "via open API"
     },
     "GenericTemplateTable": {
-        "sponsor_tab": "Parent",
-        "pre_instances_tab": "Pre-instance",
-        "user_tab": "User Defined",
-        "confirm_parameter_values_delete": "You are about to delete default parameter values",
-        "template_history_title": "History for template [{templateUid}]"
+        "sponsor_tab": "상위",
+        "pre_instances_tab": "사전 인스턴스",
+        "user_tab": "사용자 정의",
+        "confirm_parameter_values_delete": "기본 매개변수 값을 삭제하려고 합니다",
+        "template_history_title": "템플릿 [{templateUid}]의 기록"
     },
     "GenericTemplateForm": {
-        "study_indication": "Indication or disorder",
-        "study_phase": "Study phase",
-        "template_properties": "Template properties",
-        "step1_add_title": "Create template",
-        "step1_edit_title": "Edit template",
-        "step2_title": "Test template",
-        "step3_title": "Index template",
-        "step4_title": "Change description",
-        "parameter_values_title": "Edit parameter values"
+        "study_indication": "적응증 또는 장애",
+        "study_phase": "연구 단계",
+        "template_properties": "템플릿 속성",
+        "step1_add_title": "템플릿 생성",
+        "step1_edit_title": "템플릿 편집",
+        "step2_title": "템플릿 테스트",
+        "step3_title": "템플릿 인덱싱",
+        "step4_title": "변경 설명",
+        "parameter_values_title": "매개변수 값 편집"
     },
     "EndpointTemplatesView": {
         "title": "Endpoint Templates",
@@ -1313,38 +1313,38 @@
         "confirmatory_testing": "Related to confirmatory testing"
     },
     "PreInstanceForm": {
-        "step1_title": "Set template parameter values",
-        "step2_title": "Index template"
+        "step1_title": "템플릿 매개변수 값 설정",
+        "step2_title": "템플릿 인덱싱"
     },
     "ObjectiveTemplatesPreInstanceForm": {
-        "add_title": "Add objective template pre-instantiation",
-        "edit_title": "Edit objective template pre-instantiation",
-        "add_success": "Objective template pre-instantiation added",
-        "update_success": "Objective template pre-instantiation updated"
+        "add_title": "목표 템플릿 사전 인스턴스 추가",
+        "edit_title": "목표 템플릿 사전 인스턴스 편집",
+        "add_success": "목표 템플릿 사전 인스턴스가 추가되었습니다",
+        "update_success": "목표 템플릿 사전 인스턴스가 업데이트되었습니다"
     },
     "EndpointTemplatesPreInstanceForm": {
-        "add_title": "Add endpoint template pre-instantiation",
-        "edit_title": "Edit endpoint template pre-instantiation",
-        "add_success": "Endpoint template pre-instantiation added",
-        "update_success": "Endpoint template pre-instantiation updated"
+        "add_title": "엔드포인트 템플릿 사전 인스턴스 추가",
+        "edit_title": "엔드포인트 템플릿 사전 인스턴스 편집",
+        "add_success": "엔드포인트 템플릿 사전 인스턴스가 추가되었습니다",
+        "update_success": "엔드포인트 템플릿 사전 인스턴스가 업데이트되었습니다"
     },
     "CriteriaTemplatesPreInstanceForm": {
-        "add_title": "Add criteria template pre-instantiation",
-        "edit_title": "Edit criteria template pre-instantiation",
-        "add_success": "Criteria template pre-instantiation added",
-        "update_success": "Criteria template pre-instantiation updated"
+        "add_title": "기준 템플릿 사전 인스턴스 추가",
+        "edit_title": "기준 템플릿 사전 인스턴스 편집",
+        "add_success": "기준 템플릿 사전 인스턴스가 추가되었습니다",
+        "update_success": "기준 템플릿 사전 인스턴스가 업데이트되었습니다"
     },
     "ActivityTemplatesPreInstanceForm": {
-        "add_title": "Add activity template pre-instantiation",
-        "edit_title": "Edit activity template pre-instantiation",
-        "add_success": "Activity template pre-instantiation added",
-        "update_success": "Activity template pre-instantiation updated"
+        "add_title": "활동 템플릿 사전 인스턴스 추가",
+        "edit_title": "활동 템플릿 사전 인스턴스 편집",
+        "add_success": "활동 템플릿 사전 인스턴스가 추가되었습니다",
+        "update_success": "활동 템플릿 사전 인스턴스가 업데이트되었습니다"
     },
     "FootnoteTemplatesPreInstanceForm": {
-        "add_title": "Add footnote template pre-instantiation",
-        "edit_title": "Edit footnote template pre-instantiation",
-        "add_success": "Footnote template pre-instantiation added",
-        "update_success": "Footnote template pre-instantiation updated"
+        "add_title": "각주 템플릿 사전 인스턴스 추가",
+        "edit_title": "각주 템플릿 사전 인스턴스 편집",
+        "add_success": "각주 템플릿 사전 인스턴스가 추가되었습니다",
+        "update_success": "각주 템플릿 사전 인스턴스가 업데이트되었습니다"
     },
     "CtCataloguesForm": {
         "add_title": "Add a new CT Catalogue",
@@ -1745,10 +1745,10 @@
         "objective_updated": "Study objective updated"
     },
     "ParameterValueSelector": {
-        "separator": "Separator",
-        "title": "Select values",
-        "preview": "Preview with selected values",
-        "na_tooltip": "Show/hide parameter in the sentence"
+        "separator": "구분자",
+        "title": "값 선택",
+        "preview": "선택한 값으로 미리보기",
+        "na_tooltip": "문장에서 매개변수 표시/숨기기"
     },
     "StudyManageView": {
         "title": "Study List"
@@ -3914,8 +3914,8 @@
         "format": "Format"
     },
     "TemplateIndexingDialog": {
-        "title": "Edit indexing properties",
-        "update_success": "Indexing properties updated"
+        "title": "인덱싱 속성 편집",
+        "update_success": "인덱싱 속성이 업데이트되었습니다"
     },
     "CrfDuplicationForm": {
         "duplicate": "Duplicate element",

--- a/studybuilder/src/locales/pt-BR.json
+++ b/studybuilder/src/locales/pt-BR.json
@@ -222,8 +222,8 @@
             "context": "The Context attribute specifies the application domain in which this additional name is relevant. You could use for example 'CDASH/SDTM' with a 'Name' = 'DM:Demographics|DS:Disposition' and then the ODM-XML view will display it as an annotation for two SDTM Domain."
         },
         "GenericTemplateForm": {
-            "study_indication": "Indications, conditions, diseases or disorders in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies.",
-            "study_phase": "Study phases in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies."
+            "study_indication": "Indicações, condições, doenças ou distúrbios abrangidos pelo modelo. Selecione NA (não aplicável) se o modelo for genérico e não direcionado a estudos específicos.",
+            "study_phase": "Fases do estudo abrangidas pelo modelo. Selecione NA (não aplicável) se o modelo for genérico e não direcionado a estudos específicos."
         },
         "ObjectiveTemplateForm": {
             "name": "Example of objective: 'To demonstrate superiority of [CompoundDosing] [NumericValue] [Dose Unit] versus [Comparator] [NumericValue] [Dose Unit] with respect to [ActivityInstance] at [TimePoint] in patients with [DiseaseDisorder]' or 'To document the safety profile of [StudyIntervention].' Add parameters enclosed in square brackets [ and ].",
@@ -1189,22 +1189,22 @@
         "integrate_text2": "via open API"
     },
     "GenericTemplateTable": {
-        "sponsor_tab": "Parent",
-        "pre_instances_tab": "Pre-instance",
-        "user_tab": "User Defined",
-        "confirm_parameter_values_delete": "You are about to delete default parameter values",
-        "template_history_title": "History for template [{templateUid}]"
+        "sponsor_tab": "Pai",
+        "pre_instances_tab": "Pré-instância",
+        "user_tab": "Definido pelo usuário",
+        "confirm_parameter_values_delete": "Você está prestes a excluir os valores padrão de parâmetros",
+        "template_history_title": "Histórico do modelo [{templateUid}]"
     },
     "GenericTemplateForm": {
-        "study_indication": "Indication or disorder",
-        "study_phase": "Study phase",
-        "template_properties": "Template properties",
-        "step1_add_title": "Create template",
-        "step1_edit_title": "Edit template",
-        "step2_title": "Test template",
-        "step3_title": "Index template",
-        "step4_title": "Change description",
-        "parameter_values_title": "Edit parameter values"
+        "study_indication": "Indicação ou distúrbio",
+        "study_phase": "Fase do estudo",
+        "template_properties": "Propriedades do modelo",
+        "step1_add_title": "Criar modelo",
+        "step1_edit_title": "Editar modelo",
+        "step2_title": "Testar modelo",
+        "step3_title": "Indexar modelo",
+        "step4_title": "Descrição da alteração",
+        "parameter_values_title": "Editar valores de parâmetros"
     },
     "EndpointTemplatesView": {
         "title": "Endpoint Templates",
@@ -1313,38 +1313,38 @@
         "confirmatory_testing": "Related to confirmatory testing"
     },
     "PreInstanceForm": {
-        "step1_title": "Set template parameter values",
-        "step2_title": "Index template"
+        "step1_title": "Definir valores de parâmetro do modelo",
+        "step2_title": "Indexar modelo"
     },
     "ObjectiveTemplatesPreInstanceForm": {
-        "add_title": "Add objective template pre-instantiation",
-        "edit_title": "Edit objective template pre-instantiation",
-        "add_success": "Objective template pre-instantiation added",
-        "update_success": "Objective template pre-instantiation updated"
+        "add_title": "Adicionar pré-instância de modelo de objetivo",
+        "edit_title": "Editar pré-instância de modelo de objetivo",
+        "add_success": "Pré-instância de modelo de objetivo adicionada",
+        "update_success": "Pré-instância de modelo de objetivo atualizada"
     },
     "EndpointTemplatesPreInstanceForm": {
-        "add_title": "Add endpoint template pre-instantiation",
-        "edit_title": "Edit endpoint template pre-instantiation",
-        "add_success": "Endpoint template pre-instantiation added",
-        "update_success": "Endpoint template pre-instantiation updated"
+        "add_title": "Adicionar pré-instância de modelo de desfecho",
+        "edit_title": "Editar pré-instância de modelo de desfecho",
+        "add_success": "Pré-instância de modelo de desfecho adicionada",
+        "update_success": "Pré-instância de modelo de desfecho atualizada"
     },
     "CriteriaTemplatesPreInstanceForm": {
-        "add_title": "Add criteria template pre-instantiation",
-        "edit_title": "Edit criteria template pre-instantiation",
-        "add_success": "Criteria template pre-instantiation added",
-        "update_success": "Criteria template pre-instantiation updated"
+        "add_title": "Adicionar pré-instância de modelo de critério",
+        "edit_title": "Editar pré-instância de modelo de critério",
+        "add_success": "Pré-instância de modelo de critério adicionada",
+        "update_success": "Pré-instância de modelo de critério atualizada"
     },
     "ActivityTemplatesPreInstanceForm": {
-        "add_title": "Add activity template pre-instantiation",
-        "edit_title": "Edit activity template pre-instantiation",
-        "add_success": "Activity template pre-instantiation added",
-        "update_success": "Activity template pre-instantiation updated"
+        "add_title": "Adicionar pré-instância de modelo de atividade",
+        "edit_title": "Editar pré-instância de modelo de atividade",
+        "add_success": "Pré-instância de modelo de atividade adicionada",
+        "update_success": "Pré-instância de modelo de atividade atualizada"
     },
     "FootnoteTemplatesPreInstanceForm": {
-        "add_title": "Add footnote template pre-instantiation",
-        "edit_title": "Edit footnote template pre-instantiation",
-        "add_success": "Footnote template pre-instantiation added",
-        "update_success": "Footnote template pre-instantiation updated"
+        "add_title": "Adicionar pré-instância de modelo de nota de rodapé",
+        "edit_title": "Editar pré-instância de modelo de nota de rodapé",
+        "add_success": "Pré-instância de modelo de nota de rodapé adicionada",
+        "update_success": "Pré-instância de modelo de nota de rodapé atualizada"
     },
     "CtCataloguesForm": {
         "add_title": "Add a new CT Catalogue",
@@ -1745,10 +1745,10 @@
         "objective_updated": "Study objective updated"
     },
     "ParameterValueSelector": {
-        "separator": "Separator",
-        "title": "Select values",
-        "preview": "Preview with selected values",
-        "na_tooltip": "Show/hide parameter in the sentence"
+        "separator": "Separador",
+        "title": "Selecionar valores",
+        "preview": "Pré-visualizar com os valores selecionados",
+        "na_tooltip": "Mostrar/ocultar o parâmetro na frase"
     },
     "StudyManageView": {
         "title": "Study List"
@@ -3914,8 +3914,8 @@
         "format": "Format"
     },
     "TemplateIndexingDialog": {
-        "title": "Edit indexing properties",
-        "update_success": "Indexing properties updated"
+        "title": "Editar propriedades de indexação",
+        "update_success": "Propriedades de indexação atualizadas"
     },
     "CrfDuplicationForm": {
         "duplicate": "Duplicate element",

--- a/studybuilder/src/locales/zh-CN.json
+++ b/studybuilder/src/locales/zh-CN.json
@@ -222,8 +222,8 @@
       "context": "The Context attribute specifies the application domain in which this additional name is relevant. You could use for example 'CDASH/SDTM' with a 'Name' = 'DM:Demographics|DS:Disposition' and then the ODM-XML view will display it as an annotation for two SDTM Domain."
     },
     "GenericTemplateForm": {
-      "study_indication": "Indications, conditions, diseases or disorders in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies.",
-      "study_phase": "Study phases in scope for the template. Select NA (not applicable), if template is generic not targeted specific studies."
+      "study_indication": "模板适用的适应症、情况、疾病或障碍。若模板是通用且不针对特定研究，请选择 NA（不适用）。",
+      "study_phase": "模板适用的研究阶段。若模板是通用且不针对特定研究，请选择 NA（不适用）。"
     },
     "ObjectiveTemplateForm": {
       "name": "Example of objective: 'To demonstrate superiority of [CompoundDosing] [NumericValue] [Dose Unit] versus [Comparator] [NumericValue] [Dose Unit] with respect to [ActivityInstance] at [TimePoint] in patients with [DiseaseDisorder]' or 'To document the safety profile of [StudyIntervention].' Add parameters enclosed in square brackets [ and ].",
@@ -1189,22 +1189,22 @@
     "integrate_text2": "via open API"
   },
   "GenericTemplateTable": {
-    "sponsor_tab": "Parent",
-    "pre_instances_tab": "Pre-instance",
-    "user_tab": "User Defined",
-    "confirm_parameter_values_delete": "You are about to delete default parameter values",
-    "template_history_title": "History for template [{templateUid}]"
+    "sponsor_tab": "父模板",
+    "pre_instances_tab": "预实例",
+    "user_tab": "用户自定义",
+    "confirm_parameter_values_delete": "您即将删除默认参数值",
+    "template_history_title": "模板 [{templateUid}] 的历史记录"
   },
   "GenericTemplateForm": {
-    "study_indication": "Indication or disorder",
-    "study_phase": "Study phase",
-    "template_properties": "Template properties",
-    "step1_add_title": "Create template",
-    "step1_edit_title": "Edit template",
-    "step2_title": "Test template",
-    "step3_title": "Index template",
-    "step4_title": "Change description",
-    "parameter_values_title": "Edit parameter values"
+    "study_indication": "适应症或疾病",
+    "study_phase": "研究阶段",
+    "template_properties": "模板属性",
+    "step1_add_title": "创建模板",
+    "step1_edit_title": "编辑模板",
+    "step2_title": "测试模板",
+    "step3_title": "索引模板",
+    "step4_title": "变更描述",
+    "parameter_values_title": "编辑参数值"
   },
   "EndpointTemplatesView": {
     "title": "Endpoint Templates",
@@ -1313,38 +1313,38 @@
     "confirmatory_testing": "Related to confirmatory testing"
   },
   "PreInstanceForm": {
-    "step1_title": "Set template parameter values",
-    "step2_title": "Index template"
+    "step1_title": "设置模板参数值",
+    "step2_title": "索引模板"
   },
   "ObjectiveTemplatesPreInstanceForm": {
-    "add_title": "Add objective template pre-instantiation",
-    "edit_title": "Edit objective template pre-instantiation",
-    "add_success": "Objective template pre-instantiation added",
-    "update_success": "Objective template pre-instantiation updated"
+    "add_title": "添加目标模板预实例化",
+    "edit_title": "编辑目标模板预实例化",
+    "add_success": "目标模板预实例化已添加",
+    "update_success": "目标模板预实例化已更新"
   },
   "EndpointTemplatesPreInstanceForm": {
-    "add_title": "Add endpoint template pre-instantiation",
-    "edit_title": "Edit endpoint template pre-instantiation",
-    "add_success": "Endpoint template pre-instantiation added",
-    "update_success": "Endpoint template pre-instantiation updated"
+    "add_title": "添加终点模板预实例化",
+    "edit_title": "编辑终点模板预实例化",
+    "add_success": "终点模板预实例化已添加",
+    "update_success": "终点模板预实例化已更新"
   },
   "CriteriaTemplatesPreInstanceForm": {
-    "add_title": "Add criteria template pre-instantiation",
-    "edit_title": "Edit criteria template pre-instantiation",
-    "add_success": "Criteria template pre-instantiation added",
-    "update_success": "Criteria template pre-instantiation updated"
+    "add_title": "添加标准模板预实例化",
+    "edit_title": "编辑标准模板预实例化",
+    "add_success": "标准模板预实例化已添加",
+    "update_success": "标准模板预实例化已更新"
   },
   "ActivityTemplatesPreInstanceForm": {
-    "add_title": "Add activity template pre-instantiation",
-    "edit_title": "Edit activity template pre-instantiation",
-    "add_success": "Activity template pre-instantiation added",
-    "update_success": "Activity template pre-instantiation updated"
+    "add_title": "添加活动模板预实例化",
+    "edit_title": "编辑活动模板预实例化",
+    "add_success": "活动模板预实例化已添加",
+    "update_success": "活动模板预实例化已更新"
   },
   "FootnoteTemplatesPreInstanceForm": {
-    "add_title": "Add footnote template pre-instantiation",
-    "edit_title": "Edit footnote template pre-instantiation",
-    "add_success": "Footnote template pre-instantiation added",
-    "update_success": "Footnote template pre-instantiation updated"
+    "add_title": "添加脚注模板预实例化",
+    "edit_title": "编辑脚注模板预实例化",
+    "add_success": "脚注模板预实例化已添加",
+    "update_success": "脚注模板预实例化已更新"
   },
   "CtCataloguesForm": {
     "add_title": "Add a new CT Catalogue",
@@ -1745,10 +1745,10 @@
     "objective_updated": "Study objective updated"
   },
   "ParameterValueSelector": {
-    "separator": "Separator",
-    "title": "Select values",
-    "preview": "Preview with selected values",
-    "na_tooltip": "Show/hide parameter in the sentence"
+    "separator": "分隔符",
+    "title": "选择值",
+    "preview": "使用所选值预览",
+    "na_tooltip": "在句子中显示/隐藏参数"
   },
   "StudyManageView": {
     "title": "Study List"
@@ -3914,8 +3914,8 @@
     "format": "Format"
   },
   "TemplateIndexingDialog": {
-    "title": "Edit indexing properties",
-    "update_success": "Indexing properties updated"
+    "title": "编辑索引属性",
+    "update_success": "索引属性已更新"
   },
   "CrfDuplicationForm": {
     "duplicate": "Duplicate element",


### PR DESCRIPTION
## Summary
- localize GenericTemplate tables/forms across non-English locales
- translate TemplateIndexingDialog, PreInstanceForm, and ParameterValueSelector

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path' - perhaps you meant '--ignore-pattern'?)*
- `npx eslint . --ext .vue,.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689b71650184832ca6a45fbb38cb1f51