### PR TITLE
fix: correct in progress translation

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -3599,7 +3599,7 @@
         "activities_no_instructions": "Activities with no instructions:",
         "specification_tab": "Specification tabs:",
         "completed": "Completed:",
-        "in_progres": "In progres:",
+        "in_progres": "In progress:",
         "not_started": "Not started:",
         "not_applicable": "Not applicable:",
         "subject_info": "SUBJECT",


### PR DESCRIPTION
## Summary
- fix 'In progres' typo in English locale

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path')*


------
https://chatgpt.com/codex/tasks/task_e_689b71d2ccf4832c8a5d4ad7889c2390