### PR TITLE
fix: standardize meal label

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -556,7 +556,7 @@
             "expected_epoch_duration": "Pending implementation. Derived based on time from first visit in this epoch to first visit in the following epoch"
         },
         "StudyElements": {
-            "el_name": "Long-label of the element, e.g. Standardised Meal",
+            "el_name": "Long-label of the element, e.g. Standardized Meal.",
             "el_short_name": "Abbreviated/short name for the element, e.g. STD MEAL",
             "el_sub_type": "From the drop-down select the type of element",
             "el_type": "Select element type (treatment/no treatment), will subset based on element sub-type selected.",


### PR DESCRIPTION
## Summary
- standardize element long name example to US spelling

## Testing
- `npm test` *(fails: Missing script "test")*
- `yarn lint` *(fails: Invalid option '--ignore-path')*


------
https://chatgpt.com/codex/tasks/task_e_689b71cf5db0832c8ac854d85597a47e