### PR TITLE
fix: update sub-category spelling

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -403,7 +403,7 @@
             "guidance_text": "Depending on type of criteria a generic template can be defined. Example: Age ≥ 18 years at the time of signing informed consent can be parameterized to 'Age [Operator] [NumericValue] [Age Unit] at the time of signing informed consent'.",
             "indication": "Select the indication for which this template applies (select multiple if needed). Select NA if not applicable.",
             "criterion_cat": "Select one or more categories for which the criterion applies. The Age example could apply to Demography. Tick NA if not applicable. The categorisation is used for searching when selecting criteria template for a study.",
-            "criterion_sub_cat": "Select one or more sub-category that applies to the criterion. Tick NA if not applicable. The categorisation is used for searching when selecting criteria template for a study."
+            "criterion_sub_cat": "Select one or more sub-category that applies to the criterion. Tick NA if not applicable. The categorization is used for searching when selecting criteria template for a study."
         },
         "CodelistCreationForm": {
             "catalogue": "The new code list will be created in this catalog"


### PR DESCRIPTION
## Summary
- use American spelling for `criterion_sub_cat` guidance text in en-US locale

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path')*
- `npx eslint src/locales/en-US.json` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689b71cd7998832c9c99f9167c8f20fb