### PR TITLE
Add helper text for UnitForm ct_term across locales

### DIFF
--- a/studybuilder/src/locales/de-DE.json
+++ b/studybuilder/src/locales/de-DE.json
@@ -437,7 +437,7 @@
             "definition": "A description of the term."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "Wählen Sie den kontrollierten Terminologiebegriff, der diese Einheit repräsentiert.",
             "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",

--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -437,7 +437,7 @@
             "definition": "A description of the term."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "Select the controlled terminology term representing this unit.",
             "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",

--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -437,7 +437,7 @@
             "definition": "A description of the term."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "Select the controlled terminology term representing this unit.",
             "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",

--- a/studybuilder/src/locales/es-419.json
+++ b/studybuilder/src/locales/es-419.json
@@ -437,7 +437,7 @@
             "definition": "Una descripción del término."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "Seleccione el término de terminología controlada que representa esta unidad.",
             "convertible_unit": "Deslice si la unidad se puede convertir. ",
             "ucum_unit": "Seleccione la unidad equivalente en UCUM en el menú desplegable. ",
             "display_unit": "Diapositiva si esta unidad se usa como una unidad de visualización, p. ",

--- a/studybuilder/src/locales/fr-FR.json
+++ b/studybuilder/src/locales/fr-FR.json
@@ -437,7 +437,7 @@
             "definition": "A description of the term."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "Sélectionnez le terme de terminologie contrôlée représentant cette unité.",
             "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",

--- a/studybuilder/src/locales/ko-KR.json
+++ b/studybuilder/src/locales/ko-KR.json
@@ -437,7 +437,7 @@
             "definition": "A description of the term."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "이 단위를 나타내는 관리 용어를 선택합니다.",
             "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",

--- a/studybuilder/src/locales/pt-BR.json
+++ b/studybuilder/src/locales/pt-BR.json
@@ -437,7 +437,7 @@
             "definition": "A description of the term."
         },
         "UnitForm": {
-            "ct_term": "",
+            "ct_term": "Selecione o termo de terminologia controlada que representa esta unidade.",
             "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",

--- a/studybuilder/src/locales/zh-CN.json
+++ b/studybuilder/src/locales/zh-CN.json
@@ -437,7 +437,7 @@
       "definition": "术语的描述。"
     },
     "UnitForm": {
-      "ct_term": "",
+      "ct_term": "选择表示此单位的受控术语项。",
       "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
       "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
       "display_unit": "Slide if this unit is be used as a display unit, e.g. units used should be displayed in the output.",


### PR DESCRIPTION
## Summary
- add helper text describing UnitForm.ct_term in all locale packs

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npx eslint . --ext .vue,.js --config .eslintrc.js`

------
https://chatgpt.com/codex/tasks/task_e_689b8b525c94832cbc5ecf83648ab8f5