### PR TITLE
Clarify Study Arms field descriptions

### DIFF
--- a/studybuilder/src/locales/de-DE.json
+++ b/studybuilder/src/locales/de-DE.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomization list, e.g. A=AB and B=BA from the randomization list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/es-419.json
+++ b/studybuilder/src/locales/es-419.json
@@ -533,10 +533,10 @@
             "general": "Use el botón Agregar (en el menú) para agregar el objetivo necesario. "
         },
         "StudyArmsForm": {
-            "arm_name": "Etiqueta larga del arm, p. ej., Placebo",
+            "arm_name": "Etiqueta completa del arm, p. ej., Placebo",
             "arm_short_name": "Nombre abreviado del arm, p. ej., PBO",
-            "arm_type": "Investigational - intervención que se está investigando, Comparator - intervención contra la cual se compara la intervención investigadora, Placebo - si el comparador es Placebo seleccione esta opción, Observational - no se realiza intervención",
-            "arm_code": "Un código abreviado de las intervenciones en el arm, p. ej., AB para un estudio cruzado con Drug A seguido de Drug B, o PBO para un arm Placebo",
+            "arm_type": "Investigational - intervención que se está investigando; Comparator - intervención contra la cual se compara la intervención investigadora; Placebo - seleccione cuando el comparador es placebo; Observational - no se realiza intervención.",
+            "arm_code": "Un código abreviado de las intervenciones en el arm, p. ej., AB para un estudio cruzado con Drug A seguido de Drug B o PBO para un arm placebo",
             "randomisation_group": "El grupo asignado en la lista de aleatorización, p. ej., A=AB y B=BA de la lista de aleatorización.",
             "planned_number": "El número planificado de sujetos en el arm.",
             "description": "(Opcional) Una descripción del arm."

--- a/studybuilder/src/locales/fr-FR.json
+++ b/studybuilder/src/locales/fr-FR.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomization list, e.g. A=AB and B=BA from the randomization list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/ja-JP.json
+++ b/studybuilder/src/locales/ja-JP.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/ko-KR.json
+++ b/studybuilder/src/locales/ko-KR.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/pt-BR.json
+++ b/studybuilder/src/locales/pt-BR.json
@@ -533,10 +533,10 @@
             "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
         },
         "StudyArmsForm": {
-            "arm_name": "Long-label of the arm, e.g. Placebo",
+            "arm_name": "Full label of the arm, e.g., Placebo",
             "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-            "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+            "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+            "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
             "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."

--- a/studybuilder/src/locales/zh-CN.json
+++ b/studybuilder/src/locales/zh-CN.json
@@ -533,10 +533,10 @@
       "general": "Use the add button (under the menu) to add the objective needed. The objective can be based on standard templates, selected from other studies or created from scratch. Some criteria contain parameters highlighted with orange text (parameter labels) or green text (parameter values) for which new values can be selected, or the parameter omitted, by using the Edit button next to each editable objective in the table."
     },
     "StudyArmsForm": {
-      "arm_name": "Long-label of the arm, e.g. Placebo",
+      "arm_name": "Full label of the arm, e.g., Placebo",
       "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-      "arm_type": "Investigational - Intervention being investigated, Comparator - Intervention the investigational intervention is being compared against, Placebo - if comparator is Placebo select this option, Observational - No intervention is made",
-      "arm_code": "An abbreviated code of the interventions in the arm, e.g. AB for a cross-over study with Drug A followed by drug B, or  PBO for a Placebo arm",
+      "arm_type": "Investigational - intervention being investigated; Comparator - intervention the investigational intervention is compared against; Placebo - choose when the comparator is placebo; Observational - no intervention is made.",
+      "arm_code": "An abbreviated code of the interventions in the arm, e.g., AB for a cross-over study with Drug A followed by Drug B or PBO for a placebo arm",
       "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
       "planned_number": "The planned number of subjects in the arm.",
       "description": "(optional) A description of the arm."


### PR DESCRIPTION
## Summary
- clarify StudyArmsForm `arm_name` example
- split `arm_type` description into shorter clauses
- tidy `arm_code` example and spacing across locales

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path' - perhaps you meant '--ignore-pattern'?)*

------
https://chatgpt.com/codex/tasks/task_e_689b9642e1ec832c8cd691f3f9201bf4