### PR TITLE
fix: use British spelling for study epoch colour

### DIFF
--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -2957,7 +2957,7 @@
         "order": "Order",
         "add_success": "Epoch added",
         "update_success": "Epoch updated",
-        "color": "Background color (used in timeline view)",
+        "color": "Background colour (used in timeline view)",
         "name": "Epoch name",
         "epoch_number": "Epoch number",
         "epoch_type": "Epoch type",


### PR DESCRIPTION
## Summary
- use British spelling for StudyEpochForm background colour in UK locale
- review colour-related strings for consistency

## Testing
- `yarn lint src/locales/en.json` (fails: Invalid option '--ignore-path')

------
https://chatgpt.com/codex/tasks/task_e_689b96718348832c99abf177f44f9bf9