### PR TITLE
feat: add summary for library overview pages

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -950,7 +950,7 @@
         "projects": "View or create projects.",
         "clinical_programmes": "View or create clinical programs.",
         "administrative_definitions": "View or create administrative definitions.",
-        "overview_pages_description": ""
+        "overview_pages_description": "See high-level summaries of Library sections with quick navigation to detailed pages."
     },
     "Studies": {
         "description_top_before": "Under ",


### PR DESCRIPTION
## Summary
- add summary text for Library overview pages locale

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path')*
- `yarn i18n:report` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba158a024832cb2807e058fcf09b3