### PR TITLE
fix: correct announcement typo in en-US locale

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -1165,7 +1165,7 @@
             "ichm11": "ICH M11"
         },
         "admin": {
-            "announcements": "System annoucement",
+            "announcements": "System announcement",
             "feature_flags": "Feature flags"
         }
     },
@@ -4388,7 +4388,7 @@
     "SystemAnnouncementsView": {
         "title": "System announcement",
         "show_title": "Show announcement",
-        "show_help": "The annoucement will be shown at the top of StudyBuilder as a system-wide message",
+        "show_help": "The announcement will be shown at the top of StudyBuilder as a system-wide message",
         "announcement_type": "Choose type of announcement",
         "type_informative": "Informative",
         "help_informative": "An information that is not an error or potentially dangerous",


### PR DESCRIPTION
## Summary
- fix typo "annoucement" -> "announcement" in English locale

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "JSON.parse(require('fs').readFileSync('src/locales/en-US.json', 'utf8'))"`

------
https://chatgpt.com/codex/tasks/task_e_689ba1807e90832cb7e1485825e9be9d