### PR TITLE
fix typo in DesignMatrix global help text

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -3638,7 +3638,7 @@
         "planned_duration_time": "Planned study duration time"
     },
     "DesignMatrix": {
-        "global_help": "For each of the Study Arms, select the relevant elements in the given epochs. If a study element is missing then go back to the Study Elements tab to create/update the elments",
+        "global_help": "For each of the Study Arms, select the relevant elements in the given epochs. If a study element is missing then go back to the Study Elements tab to create/update the elements",
         "study_arm": "Study Arm",
         "element": "Element",
         "cell_updated": "Cell updated",


### PR DESCRIPTION
## Summary
- fix typo in DesignMatrix global help instructions

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba183a4f8832c8dbdc457b9b3c245