### PR TITLE
chore: refine British default description

### DIFF
--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -56,7 +56,7 @@
         "previous": "Previous",
         "all": "All",
         "warning": "Warning",
-        "default_description": "Lorem ipsum lorem ipsum",
+        "default_description": "No description provided.",
         "study_required_redirection": "The page requires a selected study",
         "no_study_selected": "The page requires a selected study",
         "ok": "OK",


### PR DESCRIPTION
## Summary
- refine `_global.default_description` for British English locale

## Testing
- `npx prettier --check src/locales/en.json`
- `yarn lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_689ba18d3058832c97b189cb5d2280f9