### PR TITLE
fix: correct announcement typos in en locale

### DIFF
--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -1165,7 +1165,7 @@
             "ichm11": "ICH M11"
         },
         "admin": {
-            "announcements": "System annoucement",
+            "announcements": "System announcement",
             "feature_flags": "Feature flags"
         }
     },
@@ -3638,7 +3638,7 @@
         "planned_duration_time": "Planned study duration time"
     },
     "DesignMatrix": {
-        "global_help": "For each of the Study Arms, select the relevant elements in the given epochs. If a study element is missing then go back to the Study Elements tab to create/update the elments",
+        "global_help": "For each of the Study Arms, select the relevant elements in the given epochs. If a study element is missing then go back to the Study Elements tab to create/update the elements",
         "study_arm": "Study Arm",
         "element": "Element",
         "cell_updated": "Cell updated",
@@ -4388,7 +4388,7 @@
     "SystemAnnouncementsView": {
         "title": "System announcement",
         "show_title": "Show announcement",
-        "show_help": "The annoucement will be shown at the top of StudyBuilder as a system-wide message",
+        "show_help": "The announcement will be shown at the top of StudyBuilder as a system-wide message",
         "announcement_type": "Choose type of announcement",
         "type_informative": "Informative",
         "help_informative": "An information that is not an error or potentially dangerous",


### PR DESCRIPTION
## Summary
- fix 'System annoucement' -> 'System announcement'
- fix 'The annoucement will be shown...' -> 'The announcement will be shown...'
- fix 'create/update the elments' -> 'create/update the elements'

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_689ba1c75cc0832ca15ac5f7652f8b21