### PR TITLE
Use 'metre' spelling in English locale

### DIFF
--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -438,10 +438,10 @@
         },
         "UnitForm": {
             "ct_term": "Select the controlled terminology term representing this unit.",
-            "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or meter, but the unit pH is not convertible.",
+            "convertible_unit": "Slide if the unit can be converted. e.g. mm is convertible to cm or metre, but the unit pH is not convertible.",
             "ucum_unit": "Select the equivalent unit in UCUM from the drop-down. For syntax rules see <a href='https://ucum.org/ucum.html.' target='_blank'>[Syntax Rules]<a>",
             "display_unit": "Slide if this unit is to be used as a display unit, e.g., units used should be displayed in the output.",
-            "master_unit": "Slide if this unit is the master unit of a unit dimension. All units are converted through the master unit. For example, the master unit for length is m (meter). If cm is converted to mm, it is first converted to meter using the 'conversion factor to master' and then to mm. This is often the first unit created for a unit dimension. There can only be one master unit. It does not matter which unit is the master unit.",
+            "master_unit": "Slide if this unit is the master unit of a unit dimension. All units are converted through the master unit. For example, the master unit for length is m (metre). If cm is converted to mm, it is first converted to metre using the 'conversion factor to master' and then to mm. This is often the first unit created for a unit dimension. There can only be one master unit. It does not matter which unit is the master unit.",
             "si_unit": "Slide to indicate whether a unit is a SI unit.",
             "us_unit": "Slide to indicate whether a unit is a US unit.",
             "dimension": "Selection of the Unit Dimension, that the unit belongs to, which means the unit can be converted to the other units in the same Unit Dimension, using the conversion factors defined (except when convertible unit flag is unticked) E.g. cm and mm are in the unit dimension 'length' and can be converted to each other. The naming of these are not used but should be meaningful.",


### PR DESCRIPTION
## Summary
- replace 'meter' with 'metre' in unit form descriptions

## Testing
- `yarn format src/locales/en.json`
- `yarn lint src/locales/en.json` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_689ba1cc7794832cb50ce8cac10e727f