### PR TITLE
chore(i18n): translate Korean study title and status sections

### DIFF
--- a/studybuilder/src/locales/ko-KR.json
+++ b/studybuilder/src/locales/ko-KR.json
@@ -1652,20 +1652,20 @@
         "update_success": "Intervention type updated"
     },
     "RegistryIdentifiersForm": {
-        "title": "Add or edit registry identifiers",
-        "update_success": "Registry identifiers updated",
-        "ct_gov_id": "ClinicalTrials.gov ID",
-        "eudract_id": "EUDRACT ID",
-        "universal_trial_number_utn": "Universal Trial Number (UTN)",
-        "japanese_trial_registry_id_japic": "Japanese Trial Registry ID (JAPIC)",
-        "investigational_new_drug_application_number_ind": "Investigational New Drug Application (IND) Number",
-        "eu_trial_number": "EU Trial Number",
-        "civ_id_sin_number": "CID ID SIN Number",
-        "national_clinical_trial_number": "National Clinical Trial Number",
-        "japanese_trial_registry_number_jrct": "Japanese Trial Registry Number",
-        "national_medical_products_administration_nmpa_number": "NMPA Number",
-        "eudamed_srn_number": "EUDAMED number",
-        "investigational_device_exemption_ide_number": "Investigational Device Exemption Number"
+        "title": "등록 식별자 추가 또는 편집",
+        "update_success": "등록 식별자가 업데이트되었습니다",
+        "ct_gov_id": "ClinicalTrials.gov ID (NCT 번호)",
+        "eudract_id": "EudraCT ID",
+        "universal_trial_number_utn": "범용 시험 번호 (UTN)",
+        "japanese_trial_registry_id_japic": "일본 임상시험 등록 ID (JAPIC)",
+        "investigational_new_drug_application_number_ind": "임상시험용 신약 신청 번호 (IND)",
+        "eu_trial_number": "EU 시험 번호",
+        "civ_id_sin_number": "CID ID SIN 번호",
+        "national_clinical_trial_number": "국가 임상시험 번호",
+        "japanese_trial_registry_number_jrct": "일본 임상시험 등록 번호 (jRCT)",
+        "national_medical_products_administration_nmpa_number": "NMPA 번호",
+        "eudamed_srn_number": "EUDAMED 번호",
+        "investigational_device_exemption_ide_number": "의료기기 시험 면제 번호 (IDE)"
     },
     "DurationField": {
         "label": "Unit"
@@ -1864,12 +1864,12 @@
         "intervention_type_info": "Study intervention type information"
     },
     "StudyRegistryIdentifiersView": {
-        "title": "Registry Identifiers"
+        "title": "등록 식별자"
     },
     "StudyRegistryIdentifiersSummary": {
-        "study_id": "Study ID",
-        "study_number": "Study number",
-        "registry_identifiers": "Registry identifiers"
+        "study_id": "연구 ID",
+        "study_number": "연구 번호",
+        "registry_identifiers": "등록 식별자"
     },
     "StudyPopulationView": {
         "title": "Study Population",
@@ -2162,30 +2162,30 @@
         "draft_activity_create_alert": "Selected activity is in {state} state. Please move the activity to FINAL state before creating the Activity Instance."
     },
     "StudyTitleView": {
-        "title": "Study Title",
-        "short_title": "Study Short Title",
-        "edit_title": "Edit study title"
+        "title": "연구 제목",
+        "short_title": "연구의 짧은 제목",
+        "edit_title": "연구 제목 편집"
     },
     "StudyTitleForm": {
-        "title": "Define study title",
-        "global_help": "If relevant, copy from another study and use as starting point",
-        "project_id": "Project ID",
-        "project_name": "Project name",
-        "study_id": "Study ID",
-        "study_title": "Study title",
-        "title_label": "Study title",
-        "short_title": "Short study title",
-        "title_hint": "The Title must include the name of the study intervention(s) under clinical investigation, the condition being studied, the participants included and the primary purpose, and should not be longer than 600 characters, including spaces. Two studies must not have identical titles.",
-        "update_success": "Study title updated",
-        "copy_title": "Use this study's title as a template",
-        "short_title_hint": "The short title is used for the front page of the protocol, for participant information/informed consent forms (PI/IC) and protocol synopsis in lay language (PSLL), if applicable. The short title should be in lay language and be a maximum of 300 characters. For guidance on lay language titles please refer to the User Guide on Lay Language Titles in the PI/IC toolbox on Sharepoint."
+        "title": "연구 제목 정의",
+        "global_help": "필요한 경우 다른 연구에서 복사하여 시작점으로 사용하십시오",
+        "project_id": "프로젝트 ID",
+        "project_name": "프로젝트 이름",
+        "study_id": "연구 ID",
+        "study_title": "연구 제목",
+        "title_label": "연구 제목",
+        "short_title": "짧은 연구 제목",
+        "title_hint": "제목에는 임상 시험 중인 연구 개입 이름, 연구 중인 상태, 포함된 참가자 및 주요 목적이 포함되어야 하며 공백을 포함하여 600자를 넘지 않아야 합니다. 두 연구는 동일한 제목을 가져서는 안 됩니다.",
+        "update_success": "연구 제목이 업데이트되었습니다",
+        "copy_title": "이 연구의 제목을 템플릿으로 사용",
+        "short_title_hint": "짧은 제목은 프로토콜 표지, 참가자 정보/동의서(PI/IC) 및 필요 시 일상 언어 프로토콜 요약(PSLL)에 사용됩니다. 짧은 제목은 일상 언어로 작성되어야 하며 최대 300자입니다. 일상 언어 제목에 대한 지침은 Sharepoint의 PI/IC 도구 상자에 있는 일반 언어 제목 사용자 가이드를 참조하십시오."
     },
     "StudyStatusView": {
-        "title": "Study",
-        "tab1_title": "Study Core Attributes",
-        "tab2_title": "Study Status",
-        "tab3_title": "Study Subparts",
-        "tab4_title": "Protocol Version"
+        "title": "연구",
+        "tab1_title": "연구 핵심 속성",
+        "tab2_title": "연구 상태",
+        "tab3_title": "연구 하위 구성 요소",
+        "tab4_title": "프로토콜 버전"
     },
     "StudyDataStandardVersionsView": {
         "title": "Data Standard Versions",
@@ -2217,17 +2217,17 @@
         "core_attribute": "Core attribute"
     },
     "StudyStatusTable": {
-        "unlock_success": "Study has been unlocked",
-        "confirm_delete": "Study {studyId} will be deleted",
-        "delete_success": "Study has been deleted"
+        "unlock_success": "연구가 잠금 해제되었습니다",
+        "confirm_delete": "연구 {studyId}이(가) 삭제됩니다",
+        "delete_success": "연구가 삭제되었습니다"
     },
     "StudyStatusForm": {
-        "release_title": "Release study",
-        "lock_title": "Lock study",
-        "release_description": "Release description",
-        "lock_description": "Lock description",
-        "lock_success": "Study has been locked",
-        "release_success": "Study has been released"
+        "release_title": "연구 공개",
+        "lock_title": "연구 잠금",
+        "release_description": "공개 설명",
+        "lock_description": "잠금 설명",
+        "lock_success": "연구가 잠겼습니다",
+        "release_success": "연구가 공개되었습니다"
     },
     "StudyProtocolElementsView": {
         "title": "Protocol Elements",
@@ -3552,8 +3552,8 @@
         "with_records": "With records:",
         "no_records": "No records:",
         "link": "Link",
-        "registry_identifiers": "Registry Identifiers",
-        "registry_identifiers_tab": "Registry Identifiers tab",
+        "registry_identifiers": "등록 식별자",
+        "registry_identifiers_tab": "등록 식별자 탭",
         "study_design": "Study Design",
         "study_type_tab": "Study Type tab",
         "study_arms_tab": "Study Arms tab",


### PR DESCRIPTION
## Summary
- translate study title view and form labels in ko-KR
- localize study status tabs and actions
- update registry identifier fields with standard terms like NCT number

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba9cbad4c832c87e29e24ee83f7b7