### PR TITLE
chore: translate timeframe labels to Korean

### DIFF
--- a/studybuilder/src/locales/ko-KR.json
+++ b/studybuilder/src/locales/ko-KR.json
@@ -397,7 +397,7 @@
             "endpoint_sub_category": "이 엔드 포인트가 적용되는 드롭 다운에서 하나 이상의 범주를 선택하십시오. "
         },
         "TimeframeTemplateForm": {
-            "name": "기간은 엔드 포인트의 일부로 참조 될 수 있습니다. "
+            "name": "시간 프레임은 엔드포인트의 일부로 참조될 수 있습니다. 예: from from baseline (week 0) to Week 28. 이 경우 템플릿은 'from from [Time Point Reference] ([VisitName]) to [VisitName]'이 될 수 있습니다. 매개변수는 대괄호 [ ] 안에 넣으십시오."
         },
         "CriteriaTemplateForm": {
             "guidance_text": "기준 유형에 따라 일반 템플릿을 정의 할 수 있습니다. ",
@@ -450,7 +450,7 @@
             "conversion_factor": "단위에서 마스터 장치로 정의 된 변환 계수. "
         },
         "TimeframeForm": {
-            "select_template": "시간 프레임의 인스턴스화를 만들려면 관련 라이브러리에서 선택하고 나열된 템플릿입니다."
+            "select_template": "시간 프레임 인스턴스를 생성하려면 관련 라이브러리에서 나열된 템플릿을 선택하십시오."
         },
         "StudyForm": {
             "project_id": "드롭 다운 목록에서 프로젝트 ID를 선택하십시오. ",
@@ -751,9 +751,6 @@
         "EndpointTemplatesTable": {
             "general": "엔드 포인트의 일반 템플릿은 여기에 정의되어 있습니다. "
         },
-        "TimeframeTemplatesTable": {
-            "general": "시간 프레임을위한 일반 템플릿은 여기에 정의되어 있습니다. "
-        },
         "CriteriaTemplatesTable": {
             "general": "다양한 유형의 기준에 대한 일반 템플릿이 여기에 정의되어 있습니다. "
         },
@@ -766,8 +763,11 @@
         "EndpointsTable": {
             "general": "엔드 포인트 목록 및 기반 템플릿 및 엔드 포인트를 사용한 연구 수. "
         },
+        "TimeframeTemplatesTable": {
+            "general": "시간 프레임에 대한 일반 템플릿은 여기에서 정의됩니다. 새 템플릿을 추가하려면 + 버튼을 클릭하십시오. 사용자 정의 템플릿에서는 다른 연구에서 정의 중인 템플릿을 볼 수 있습니다. 템플릿을 사용 가능하게 하려면 승인되어야 합니다. 템플릿 왼쪽의 컨텍스트 메뉴(세로 점 3개)에서 승인을 사용하십시오. 매개변수의 기본값을 설정하려면 컨텍스트 메뉴의 '기본값'을 사용하십시오."
+        },
         "TimeframesTable": {
-            "general": "시간 프레임 목록 및 기준 템플릿 및 기간을 사용한 연구 수. "
+            "general": "시간 프레임과 해당 기반 템플릿, 그리고 각 시간을 사용하는 연구 수를 보여줍니다. 템플릿에서 특정 시간 프레임을 생성하려면 표 우측 상단의 +-버튼을 클릭하십시오."
         },
         "StudyPurposeView": {
             "general": "연구의 전반적인 근거를 설명하는 성명서. ",
@@ -1211,7 +1211,7 @@
         "endpoints": "Endpoint titles"
     },
     "TimeframeTemplatesView": {
-        "title": "Time Frame Templates"
+        "title": "시간 프레임 템플릿"
     },
     "ObjectiveTemplateTable": {
         "title": "Objective templates",
@@ -1251,19 +1251,19 @@
         "conflict_title": "This Controlled Terminology Term doesn't contain a FINAL version on the Effective Date of the CTPackage selected by the Data Standard Versions"
     },
     "TimeframeTemplateTable": {
-        "title": "Time frame templates",
-        "singular_title": "Time frame template",
-        "rot_uri": "Root objective",
-        "actions": "Actions",
-        "add": "Add template",
-        "approve_success": "Template is now in Final state",
-        "new_version_success": "New version created",
-        "inactivate_success": "Template inactivated",
-        "reactivate_success": "Template reactivated",
-        "history": "Show template history",
-        "add_template": "Add a new time frame template",
-        "new_version_default_description": "New version",
-        "delete_success": "Timeframe template has been deleted"
+        "title": "시간 프레임 템플릿",
+        "singular_title": "시간 프레임 템플릿",
+        "rot_uri": "루트 목표",
+        "actions": "작업",
+        "add": "템플릿 추가",
+        "approve_success": "템플릿이 이제 최종 상태입니다",
+        "new_version_success": "새 버전이 생성되었습니다",
+        "inactivate_success": "템플릿이 비활성화되었습니다",
+        "reactivate_success": "템플릿이 재활성화되었습니다",
+        "history": "템플릿 기록 보기",
+        "add_template": "새 시간 프레임 템플릿 추가",
+        "new_version_default_description": "새 버전",
+        "delete_success": "시간 프레임 템플릿이 삭제되었습니다"
     },
     "EndpointTemplateTable": {
         "title": "Endpoint templates",
@@ -1356,14 +1356,14 @@
         "update_success": "Objective template updated"
     },
     "TimeframeTemplateForm": {
-        "add_title": "Add time frame template",
-        "edit_title": "Edit time frame template",
-        "name": "Template",
-        "add_success": "Time frame template added",
-        "update_success": "Time frame template updated",
-        "verify_syntax": "Verify syntax",
-        "valid_syntax": "This syntax is valid",
-        "invalid_syntax": "This syntax is invalid"
+        "add_title": "시간 프레임 템플릿 추가",
+        "edit_title": "시간 프레임 템플릿 편집",
+        "name": "템플릿",
+        "add_success": "시간 프레임 템플릿이 추가되었습니다",
+        "update_success": "시간 프레임 템플릿이 업데이트되었습니다",
+        "verify_syntax": "구문 확인",
+        "valid_syntax": "이 구문은 유효합니다",
+        "invalid_syntax": "이 구문은 유효하지 않습니다"
     },
     "HistoryTable": {
         "title": "History for",
@@ -1474,30 +1474,30 @@
         "objective_label": "Objective"
     },
     "TimeframeTable": {
-        "delete_success": "Time frame has been deleted",
-        "approve_success": "Time frame is now in Final state",
-        "inactivate_success": "Time frame inactivated",
-        "reactivate_success": "Time frame reactivated",
-        "singular_title": "Time frame",
-        "item_history_title": "History for time frame [{timeframe}]",
-        "show_studies": "Display studies using this time frame"
+        "delete_success": "시간 프레임이 삭제되었습니다",
+        "approve_success": "시간 프레임이 이제 최종 상태입니다",
+        "inactivate_success": "시간 프레임이 비활성화되었습니다",
+        "reactivate_success": "시간 프레임이 재활성화되었습니다",
+        "singular_title": "시간 프레임",
+        "item_history_title": "시간 프레임 [{timeframe}]의 기록",
+        "show_studies": "이 시간 프레임을 사용하는 연구 표시"
     },
     "TimeframeForm": {
-        "add_title": "Add time frame from a template",
-        "edit_title": "Edit time frame",
-        "add_success": "Time frame added",
-        "current_name": "The current name is:",
-        "preview_name": "Name preview with selected parameters:",
-        "select_params": "Select your parameters:",
-        "timeframe_name": "Time frame:",
-        "template_name": "Template:",
-        "parameters_updated": "Updated parameters",
-        "current_timeframe": "Current time frame:",
-        "update_success": "Time frame updated",
-        "select_template": "Time frame template"
+        "add_title": "템플릿에서 시간 프레임 추가",
+        "edit_title": "시간 프레임 편집",
+        "add_success": "시간 프레임이 추가되었습니다",
+        "current_name": "현재 이름:",
+        "preview_name": "선택한 매개변수로 이름 미리보기:",
+        "select_params": "매개변수를 선택하십시오:",
+        "timeframe_name": "시간 프레임:",
+        "template_name": "템플릿:",
+        "parameters_updated": "매개변수 업데이트됨",
+        "current_timeframe": "현재 시간 프레임:",
+        "update_success": "시간 프레임이 업데이트되었습니다",
+        "select_template": "시간 프레임 템플릿"
     },
     "TimeframesView": {
-        "title": "Time Frames"
+        "title": "시간 프레임"
     },
     "CriteriaView": {
         "title": "Criteria"


### PR DESCRIPTION
## Summary
- localize Timeframe tables, views, and forms in Korean
- translate Timeframe help text and success messages

## Testing
- `yarn lint` *(fails: Invalid option '--ignore-path' - perhaps you meant '--ignore-pattern'?)*

------
https://chatgpt.com/codex/tasks/task_e_689ba9cd6170832c938be2495ab41114