### PR TITLE
refine StudyArmsForm help text punctuation

### DIFF
--- a/studybuilder/src/locales/en.json
+++ b/studybuilder/src/locales/en.json
@@ -534,9 +534,9 @@
         },
         "StudyArmsForm": {
             "arm_name": "Full label of the arm, e.g., Placebo.",
-            "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational: intervention being investigated. Comparator: intervention the investigational intervention is compared against. Placebo: choose when the comparator is placebo. Observational: no intervention is made.",
-            "arm_code": "An abbreviated code for the arm's interventions, e.g., AB for a crossover study with Drug A followed by Drug B, or PBO for a placebo arm.",
+            "arm_short_name": "Abbreviated name of the arm, e.g., PBO",
+            "arm_type": "Investigational: intervention being investigated; Comparator: intervention the investigational intervention is compared against; Placebo: choose when the comparator is placebo; Observational: no intervention is made.",
+            "arm_code": "An abbreviated code for the arm's interventions, e.g., AB for a crossover study with Drug A followed by Drug B; or PBO for a placebo arm.",
             "randomisation_group": "The group assigned in the randomisation list, e.g. A=AB and B=BA from the randomisation list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."


### PR DESCRIPTION
## Summary
- clarify Study Arms form help text by adding commas after "e.g."
- separate arm type descriptions with semicolons for readability

## Testing
- `yarn lint`
- `jq . src/locales/en.json`


------
https://chatgpt.com/codex/tasks/task_e_689cb71fc334832c8c70968eb2298143