### PR TITLE
refactor: clarify arm form text

### DIFF
--- a/studybuilder/src/locales/en-US.json
+++ b/studybuilder/src/locales/en-US.json
@@ -534,9 +534,9 @@
         },
         "StudyArmsForm": {
             "arm_name": "Full label of the arm, e.g., Placebo.",
-            "arm_short_name": "Abbreviated name of the arm, e.g. PBO",
-            "arm_type": "Investigational: intervention being investigated. Comparator: intervention the investigational intervention is compared against. Placebo: choose when the comparator is placebo. Observational: no intervention is made.",
-            "arm_code": "An abbreviated code for the arm's interventions, e.g., AB for a crossover study with Drug A followed by Drug B, or PBO for a placebo arm.",
+            "arm_short_name": "Abbreviated name of the arm, e.g., PBO",
+            "arm_type": "Investigational: intervention being investigated; Comparator: intervention the investigational intervention is compared against; Placebo: choose when the comparator is placebo; Observational: no intervention is made.",
+            "arm_code": "An abbreviated code for the arm's interventions, e.g., AB for a crossover study with Drug A followed by Drug B; PBO for a placebo arm.",
             "randomisation_group": "The group assigned in the randomization list, e.g. A=AB and B=BA from the randomization list.",
             "planned_number": "The planned number of subjects in the arm.",
             "description": "(optional) A description of the arm."


### PR DESCRIPTION
## Summary
- clarify examples for StudyArmsForm translations
- rewrite StudyArmsForm arm type description with semicolons

## Testing
- `npx prettier -c src/locales/en-US.json`


------
https://chatgpt.com/codex/tasks/task_e_689cb72744f4832c9e7864d8c97d1a75